### PR TITLE
Remove unnecessary dependencies from Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,23 +4,14 @@ authors = ["Petr Krysl <pkrysl@ucsd.edu>"]
 version = "0.3.0"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-DataDrop = "aa547a04-dd37-49ab-8e73-656744f8a8fc"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-BenchmarkTools = "^1.3"
-DataDrop = "^0.1"
-DataStructures = "^0.18"
 OffsetArrays = "^1.11"
-Revise = "^3.3"
 julia = "^1.6"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DataDrop = "aa547a04-dd37-49ab-8e73-656744f8a8fc"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
* eventually move them to test/Project.toml

These dependencies are necessary only for testing, not for using the package.

In fact, with this PR, this package would be almost self-contained.   

