### PR TITLE
Prepare for finite fields

### DIFF
--- a/src/Problem/SpkProblem.jl
+++ b/src/Problem/SpkProblem.jl
@@ -143,7 +143,7 @@ end
 
 Construct a problem.
 """
-function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=zero(FT), info = "") where {IT<:BlasInt, FT}
+function _Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=zero(FT), info = "") where {IT<:BlasInt, FT}
     lenlink = nnz
     lenhead = ncols
     lenrhs = nrows
@@ -167,6 +167,10 @@ function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=zero(FT), info = "") 
         rscales, cscales, x, rhs)
 end
 
+Problem(nrows,ncols) = _Problem(nrows,ncols,2500,zero(Float64))
+Problem(nrows,ncols,nnz) = _Problem(nrows,ncols,nnz,zero(Float64))         
+Problem(nrows,ncols,nnz,z) = _Problem(nrows,ncols,nnz,z)
+
 """
     inaij!(p::Problem{IT,FT}, rnum, cnum, aij=zero(FT)) where {IT,FT}
 
@@ -184,7 +188,7 @@ function inaij!(p::Problem{IT,FT}, rnum, cnum, aij=zero(FT)) where {IT<:BlasInt,
         p.lenlink = max(2 * p.lenlink, 3 * p.ncols)
         p.link = __extend(p.link, p.lenlink)
         p.rowsubs = __extend(p.rowsubs, p.lenlink)
-        p.values = __extend(p.values, p.lenlink, _BIGGY())
+        p.values = __extend(p.values, p.lenlink, _BIGGY(FT))
     end
 
     p.nrows = max(rnum, p.nrows)
@@ -208,7 +212,7 @@ function inaij!(p::Problem{IT,FT}, rnum, cnum, aij=zero(FT)) where {IT<:BlasInt,
             break
         end
         if (p.rowsubs[ptr] == rnum)
-            if (p.values[ptr] == _BIGGY())
+            if (p.values[ptr] == _BIGGY(FT))
                 p.nnz = p.nnz + 1
                 p.values[ptr] = aij
                 if (rnum == cnum)
@@ -480,7 +484,7 @@ function computeresidual(p::Problem, res::Vector{FT}, xin::Vector{FT} = FT[], mt
         ptr = p.head[cnum]; t = x[cnum]
         while (ptr > 0)
             rnum = p.rowsubs[ptr];  temp = p.values[ptr]
-            if (temp != _BIGGY())
+            if (temp != _BIGGY(FT))
                 r[rnum] -= t * temp
                 if (rnum != cnum && flag == 1)
                     u = x[rnum]

--- a/src/Problem/SpkProblem.jl
+++ b/src/Problem/SpkProblem.jl
@@ -139,11 +139,11 @@ mutable struct Problem{IT<:BlasInt, FT}
 end
 
 """
-    Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where {IT, FT}
+    Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=zero(FT), info = "") where {IT, FT}
 
 Construct a problem.
 """
-function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where {IT<:BlasInt, FT}
+function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=zero(FT), info = "") where {IT<:BlasInt, FT}
     lenlink = nnz
     lenhead = ncols
     lenrhs = nrows
@@ -158,7 +158,7 @@ function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where
     x = fill(zero(FT), lenhead)
     link = fill(zero(IT), lenlink)
     rowsubs = fill(zero(IT), lenlink)
-    values = fill(_BIGGY(), lenlink)
+    values = fill(_BIGGY(FT), lenlink)
     rscales = FT[]
     cscales = FT[]
     
@@ -411,7 +411,7 @@ function makerhs!(p::Problem, x::Vector{FT}, mtype = "T") where {FT}
         p.x .= FT.(1:p.ncols)
     end
 
-    p.rhs .= 0.0
+    p.rhs .= zero(FT)
     res = deepcopy(p.rhs)
 
     computeresidual(p, res, p.x, mtype)

--- a/src/SparseMethod/SpkLUFactor.jl
+++ b/src/SparseMethod/SpkLUFactor.jl
@@ -65,7 +65,7 @@ function _lufactor!(n::IT, nsuper::IT, xsuper::Vector{IT}, snode::Vector{IT}, xl
     @assert length(xunz) == (n + 1)
     @assert length(ipvt) == n
 
-    ONE = FT(1.0)
+    ONE = one(FT)
     
     link = fill(zero(IT), nsuper)
     lngth = fill(zero(IT), nsuper)
@@ -278,8 +278,8 @@ function _lulsolve!(nsuper::IT, xsuper::Vector{IT}, xlindx::Vector{IT}, lindx::V
 # -  -  -  -  -  -  -  -  -  -
 #    constants.
 # -  -  -  -  -  -  -  -  -  -
-    ONE = FT(1.0)
-    ZERO = FT(0.0)
+    ONE = one(FT)
+    ZERO = zero(FT)
 
     if  (nsuper <= 0)  return false; end
 
@@ -331,8 +331,8 @@ function _luusolve!(n::IT, nsuper::IT, xsuper::Vector{IT}, xlindx::Vector{IT}, l
 # integer :: length, maxlength
 # real(double), dimension(:), allocatable :: temp
 
-    ONE = FT(1.0)
-    ZERO = FT(0.0)
+    ONE = one(FT)
+    ZERO = zero(FT)
 
     if  (nsuper <= 0)  return; end
 

--- a/src/Utilities/GenericBlasLapackFragments.jl
+++ b/src/Utilities/GenericBlasLapackFragments.jl
@@ -42,9 +42,16 @@ Base.getindex(A::StridedReshape,i)= @inbounds A.v[i]
 Base.setindex!(A::StridedReshape,v,i)= @inbounds A.v[i]=v
 
 
+@static if VERSION< v"1.7"
+    abstract type PivotingStrategy end
+    struct RowNonZero <: PivotingStrategy end
+    struct RowMaximum <: PivotingStrategy end
+    struct NoPivot <: PivotingStrategy end
+    lupivottype(::Type{T}) where {T} = RowMaximum()
+end
 
 
-@static if VERSION< v"1.9"
+@static if  VERSION >= v"1.7" && VERSION< v"1.9" 
     struct RowNonZero <: LinearAlgebra.PivotingStrategy end
     lupivottype(::Type{T}) where {T} = RowMaximum()
 end

--- a/src/Utilities/GenericBlasLapackFragments.jl
+++ b/src/Utilities/GenericBlasLapackFragments.jl
@@ -41,32 +41,34 @@ Base.setindex!(A::StridedReshape,v,i,j)= @inbounds A.v[idx(A,i,j)]=v
 Base.getindex(A::StridedReshape,i)= @inbounds A.v[i]
 Base.setindex!(A::StridedReshape,v,i)= @inbounds A.v[i]=v
 
-struct RowNonZero end
+
+
+
+@static if VERSION< v"1.9"
+    struct RowNonZero <: LinearAlgebra.PivotingStrategy end
+    lupivottype(::Type{T}) where {T} = RowMaximum()
+end
+
+
+@static if VERSION >= v"1.9"
+    import LinearAlgebra: lupivottype
+end
+
 #
-# LU factorization adapted from generic_lufact! (https://github.com/JuliaLang/LinearAlgebra.jl/blob/main/src/lu.jl).
+# LU factorization adapted from generic_lufact! (https://github.com/JuliaLang/LinearAlgebra.jl/blob/main/src/lu.jl)
+# with support of RowNonZero pivoting for finite fields etc.
 # Originally it is (like many other LA operators) defined for StridedMatrix which is a union and not an abstract type,
 # so we cannot use that code directly. See https://github.com/JuliaLang/julia/issues/2345 for some discussion about this.
 #
 # Modifications:
 # - Use ipiv passed instead of creating one
 # - No need to return LU object 
-# - Remove unused parameters - always do pivoting anyway
 #
 #
-function ggetrf!(m,n,a::AbstractVector{FT},lda,ipiv) where FT
+function ggetrf!(m,n,a::AbstractVector{FT},lda,ipiv; pivot::Union{NoPivot,RowMaximum,RowNonZero}=lupivottype(FT)) where FT
 
     minmn = min(m,n)
     A=StridedReshape(a,lda)
-    
-    
-    if FT<:AbstractFloat
-        pivot=RowMaximum()
-    elseif FT<:Complex{T} where T<:AbstractFloat
-        pivot=RowMaximum()
-    else
-        pivot=RowNonZero()
-    end
-        
     begin
         for k = 1:minmn
             # find index max

--- a/src/Utilities/SpkUtilities.jl
+++ b/src/Utilities/SpkUtilities.jl
@@ -4,7 +4,7 @@ See the comments below in the interface section of the module.
 """
 module SpkUtilities
 
-_BIGGY() = typemax(Float64)
+_BIGGY(T) = typemax(T)
 
 
 #     __extend(v::Vector, newlen::Integer, flagval=zero(eltype(v)))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+GaloisFields = "8d0d7f98-d412-5cd4-8397-071c807280aa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MultiFloats = "bdf0d083-296b-4888-a5b6-7498122e68a5"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,3 +36,7 @@ end
     include("test_generic.jl")
 end
 
+@time @testset "Galois" begin
+    include("test_galois.jl")
+end
+

--- a/test/test_galois.jl
+++ b/test/test_galois.jl
@@ -1,0 +1,38 @@
+module GaloisTest
+using Test
+using LinearAlgebra
+using SparseArrays
+using Sparspak
+using Sparspak.SpkProblem: insparse!, outsparse
+using Sparspak.SpkSparseSolver: SparseSolver, solve!
+using GaloisFields
+
+
+
+function _test(T,n)
+    spm = sprand(T, n, n, 1/n)
+    for i=1:n
+        spm[i,i]=one(T)
+    end
+    x=rand(T,n)
+    b=spm*x
+    p = Sparspak.SpkProblem.Problem(n, n, nnz(spm), zero(T))
+    Sparspak.SpkProblem.insparse!(p, spm);
+    Sparspak.SpkProblem.infullrhs!(p, b);
+    s = SparseSolver(p)
+    solve!(s)
+    @test x==p.x
+end
+
+Base.typemax(::Type{T}) where T<:GaloisFields.AbstractGaloisField=one(T)
+
+const F17=@GaloisField 17
+
+_test(F17, 10)
+_test(F17, 100)
+
+const F127=@GaloisField 127
+_test(F127, 10)
+
+end
+

--- a/test/test_problem.jl
+++ b/test/test_problem.jl
@@ -44,7 +44,7 @@ function _test()
     @test norm(a - a1) / norm(a) < 1.0e-9
     a = __extend(a, 2, 2)
     a1 = [0.3814043930778628 0.07295808459382358 Inf Inf Inf; 0.5435778459423668 0.018608588657332392 Inf Inf Inf; Inf Inf Inf Inf Inf]
-    a = __extend(a, 3, 5, SpkUtilities._BIGGY())
+    a = __extend(a, 3, 5, SpkUtilities._BIGGY(Float64))
     @test a == a1
     return true
 end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -53,7 +53,7 @@ function _test()
     @test norm(a - a1) / norm(a) < 1.0e-9
     a = __extend(a, 2, 2)
     a1 = [0.3814043930778628 0.07295808459382358 Inf Inf Inf; 0.5435778459423668 0.018608588657332392 Inf Inf Inf; Inf Inf Inf Inf Inf]
-    a = __extend(a, 3, 5, SpkUtilities._BIGGY())
+    a = __extend(a, 3, 5, SpkUtilities._BIGGY(Float64))
     @test a == a1
     return true
 end


### PR DESCRIPTION
triggered by https://discourse.julialang.org/t/from-toy-to-production-code-with-sparse-matrix-and-sparse-direct-factorizations/89105/13

Just a first try. Not yet ready for merge.

Main blocking things:
- [x] How to  pass pivoting strategy ? A the moment it is gussed from the type. EDIT: We can borrow and backport the idea from Julia 1.9.
- [ ] What does _BIGGY() really do ? In the moment I replaced it by typemax(FT) resp. one(FT) for GaloisFields.  EDIT: it is used as an "uninitialized" marker. Would have to think a better way.
- [ ] EDIT: scalable, random (?) nonsingular sparse test matrices over finite fields ?
- [x] EDIT: Will have to define more of the pivoting stuff missing in LinearAlgebra for 1.6
- [ ] EDIT EDIT: Finite field packages like GaloisFields.jl need to implement `lupivottype(T)=RowNonZero()`, which should be no problem. However for compiling, `abs`, `isless` are needed as well. Same in the moment for Julia linear algebra. May be this can be avoided by restructuring the code.

Otherwise, for GaloisFields.jl the PR works.

