### PR TITLE
remove unused type variable

### DIFF
--- a/src/SparseMethod/SpkSparseSolver.jl
+++ b/src/SparseMethod/SpkSparseSolver.jl
@@ -104,7 +104,7 @@ function findorder!(s::SparseSolver{IT}, orderfunction::F) where {IT, F}
 end
 
 """
-    findorder!(s::SparseSolver{IT}) where {IT, F}
+    findorder!(s::SparseSolver{IT}) where {IT}
 
 Find reordering of the coefficient matrix using the default method.
 
@@ -113,7 +113,7 @@ the order function is applied.
 
 Finding the ordering invalidates symbolic factorization.
 """
-function findorder!(s::SparseSolver{IT}) where {IT, F}
+function findorder!(s::SparseSolver{IT}) where {IT}
     if (s._orderdone)
         return true
     end


### PR DESCRIPTION
I found this in our CI tests of Trixi.jl: https://github.com/trixi-framework/Trixi.jl/actions/runs/3805067166/jobs/6472726862 Unused type variables can hurt performance, so it's better to remove them.