### PR TITLE
set version to v0.3.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sparspak"
 uuid = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
 authors = ["Petr Krysl <pkrysl@ucsd.edu>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
Would you mind creating a new release after merging #14 to fix CI of downstream packages using `@test_nowarn` for testing Julia v1.9?