### PR TITLE
Update failing cases in test_smallmatrix.jl

### DIFF
--- a/test/test_smallmatrix.jl
+++ b/test/test_smallmatrix.jl
@@ -16,6 +16,7 @@ using Sparspak.SpkSparseSolver
 #     end
 # end
 
+
 function ttsparspaklu(;n=4,p=0.3)
     for i=1:1000
         println(i)
@@ -65,7 +66,7 @@ function simpletest1(;n=4)
 end
 
 #
-# May be another bug: fails in pkLUFactor.jl:245
+# Fails in SpkLUFactor.jl:245
 #
 function simpletest2()
     A=[1.21883    0.0  0.0      0.942235;
@@ -83,8 +84,33 @@ function simpletest2()
     @test SpkSparseSolver.factor!(s)
 end
 
+#
+# Fails in SpkSparseBase.jl:390
+#
+function simpletest3()
+    A=[   1.0       0.0       0.0      0.0;
+          0.0       1.45565   0.0      0.0;
+          0.0       0.0       1.11667  0.0;
+          0.511585  0.159678  0.0      1.0]
+    A=sparse(A)
+    pr = SpkProblem.Problem(4,4)
+    SpkProblem.insparse!(pr, A)
+    s = SpkSparseSolver.SparseSolver(pr)
+    SpkSparseSolver.findorder!(s)
+    SpkSparseSolver.symbolicfactor!(s)
+    SpkSparseSolver.inmatrix!(s)
+    @test SpkSparseSolver.factor!(s)
+end
+
+
+
+
+
+
+
 simpletest1()
 simpletest2()
+simpletest3()
 ttsparspak()
 ttsparspaklu()
 


### PR DESCRIPTION
To continue the discussion in #17: 

I also tried your fix, it appears to work with most of the error cases generated with ttsparspaklu(). With less probability generates two more errors, sample matrices are in simpletest2()
and simpletest3() (I may reorganize these a bit later on).

My feeling is that there is a bug in handling structurally nonsymmetric matrices. Most testcases we have (I generated more in ExtendableSparse), and also PDEs in general lead to structurally symmetric matrices, so we didn't see a problem.

I am curious what the Fortran code does with the matrices from simpletest1, simpletest2 and simpletest3. 

