### PR TITLE
Replace isstructuresymmetric method

### DIFF
--- a/src/Graph/SpkGraph.jl
+++ b/src/Graph/SpkGraph.jl
@@ -318,25 +318,22 @@ end
 
 Determines if a graph is structurally symmetric.
 
-Important assumption:
-It is assumed that the adjacency lists are in increasing order.
- 
 Output: either true or false
 """
 function isstructuresymmetric(g::Graph{IT}) where {IT}
-    first = deepcopy(g.xadj[1:g.nv])
-    for i in 1: g.nv
-        if (first[i]  < g.xadj[i + 1])
-            if (g.adj[first[i]] < i) 
-                return false
+    function findentry(i,j)
+        for k = g.xadj[i]:g.xadj[i+1]-1
+            if g.adj[k]==j
+                return true
             end
         end
-        for j in first[i]:(g.xadj[i + 1] - 1)
-            k = g.adj[j]
-            if first[k] <= length(g.adj) && (g.adj[first[k]] != i)   
+        return false
+    end
+    for i in 1: g.nv
+        for k = g.xadj[i]:g.xadj[i+1]-1
+            j = g.adj[k]
+            if !findentry(j,i)
                 return false
-            else
-                first[k] = first[k] + 1
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,5 @@
 using Test
 
-#
-# Error in LinearSolve - once fixed, move to the end...
-#
-@time @testset "Smallmatrix" begin
-    include("test_smallmatrix.jl")
-end
-
 @time @testset "Problem" begin
     include("test_problem.jl")
 end
@@ -43,6 +36,7 @@ end
     include("test_cscinterface.jl")
 end
 
-@time @testset "Small tricky problem" begin
-    include("test_small.jl")
+@time @testset "Structurally unsymmetric" begin
+    include("test_structunsymm.jl")
 end
+

--- a/test/test_structunsymm.jl
+++ b/test/test_structunsymm.jl
@@ -1,4 +1,4 @@
-#using LinearSolve
+module structurally_unsymmetric
 using Test
 using Sparspak
 using Random, SparseArrays, LinearAlgebra
@@ -6,55 +6,9 @@ using Sparspak.SpkOrdering
 using Sparspak.SpkProblem
 using Sparspak.SpkSparseSolver
 
-# function ttlinsolve(;n=4,p=0.3)
-#     for i=1:1000
-#         println(i)
-#         A = sprand(n, n, p) + I
-#         b = rand(n)
-#         prob = LinearProblem(A, b)
-#         sol = solve(prob, SparspakFactorization())
-#     end
-# end
-
-
-function ttsparspaklu(;n=4,p=0.3)
-    for i=1:1000
-        println(i)
-        A = sprand(n, n, p) + I
-        b = rand(n)
-        display(Matrix(A))
-        x=sparspaklu(A)\b
-        @assert norm(x - A\b)<1.0e-10
-    end
-end
-
-function ttsparspak(;n=4,p=0.3)
-    for i=1:1000
-        println(i)
-        A = sprand(n, n, p) + I
-        b = rand(n)
-        @show A.colptr
-        @show A.rowval
-        display(Matrix(A))
-        
-        pr = SpkProblem.Problem(n,n)
-        SpkProblem.insparse!(pr, A)
-        Sparspak.SpkProblem.infullrhs!(pr, b)
-        s = SpkSparseSolver.SparseSolver(pr)
-        SpkSparseSolver.findorder!(s)
-        SpkSparseSolver.symbolicfactor!(s)
-        SpkSparseSolver.inmatrix!(s)
-        SpkSparseSolver.factor!(s)
-        SpkSparseSolver.solve!(s)
-
-        @test norm(pr.x - A\b)<1.0e-10
-    end
-    true
-end
 
 #
-# This is so far the simplest test problem occuring
-# It fails in issymmetric, SpkGraph.jl:336
+# Used to fail in issymmetric, SpkGraph.jl:336
 #
 function simpletest1(;n=4)
     A = sparse(Diagonal(ones(n)))
@@ -66,7 +20,7 @@ function simpletest1(;n=4)
 end
 
 #
-# Fails in SpkLUFactor.jl:245
+# Used to fail in SpkLUFactor.jl:245
 #
 function simpletest2()
     A=[1.21883    0.0  0.0      0.942235;
@@ -85,7 +39,7 @@ function simpletest2()
 end
 
 #
-# Fails in SpkSparseBase.jl:390
+# Used to fail in  SpkSparseBase.jl:390
 #
 function simpletest3()
     A=[   1.0       0.0       0.0      0.0;
@@ -103,8 +57,37 @@ function simpletest3()
 end
 
 
+function ttsparspak(;n=4,p=0.3)
+    for i=1:1000
+        A = sprand(n, n, p) + I
+        b = rand(n)
+        
+        pr = SpkProblem.Problem(n,n)
+        SpkProblem.insparse!(pr, A)
+        Sparspak.SpkProblem.infullrhs!(pr, b)
+        s = SpkSparseSolver.SparseSolver(pr)
+        SpkSparseSolver.findorder!(s)
+        SpkSparseSolver.symbolicfactor!(s)
+        SpkSparseSolver.inmatrix!(s)
+        SpkSparseSolver.factor!(s)
+        SpkSparseSolver.solve!(s)
+        @assert norm(pr.x - A\b)<1.0e-9
+    end
+    @test true
+end
 
 
+function ttsparspaklu(;n=4,p=0.3)
+    for i=1:1000
+        # println(i)
+        A = sprand(n, n, p) + I
+        b = rand(n)
+        # display(Matrix(A))
+        x=sparspaklu(A)\b
+        @assert norm(x - A\b)<1.0e-9
+    end
+    @test true
+end
 
 
 
@@ -114,3 +97,4 @@ simpletest3()
 ttsparspak()
 ttsparspaklu()
 
+end


### PR DESCRIPTION
The original method seems to try to record if a structure symmetry pair already has been found and therefore introduced the marker array `first`. For some corner cases (easily to generate via sprand...) this fails. Attempts to fix this failed as well. The new method is slightly less efficient (but uses no additional memory...), but passes all tests. The performance penalty IMHO is be worth the correctness and at least buys time for a more profound fix later on.

This continues from #18 