### PR TITLE
Update csc interface

### DIFF
--- a/src/Problem/SpkProblem.jl
+++ b/src/Problem/SpkProblem.jl
@@ -167,6 +167,10 @@ function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where
         rscales, cscales, x, rhs)
 end
 
+function Problem(nrows::IT, ncols::IT, z::FT=0.0) where {IT<:BlasInt, FT}
+    return Problem(nrows, ncols, 2500, z)
+end
+
 """
     inaij!(p::Problem{IT,FT}, rnum, cnum, aij=zero(FT)) where {IT,FT}
 

--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -253,26 +253,27 @@ function sparspaklu!(lu::SparseSolver{IT,FT}, m::SparseMatrixCSC{FT,IT}) where {
     lu
 end
 
-
 """
-    ldiv(u,lu::SparseSolver,v)
+    ldiv!(u, lu::SparseSolver{IT,FT}, v) where {IT,FT}
 
-Left division for SparseSolver
+Left division for SparseSolver.
+
+The solution is returned in `u`. The right hand side vector is `v`.
 """
 function LinearAlgebra.ldiv!(u, lu::SparseSolver{IT,FT}, v) where {IT,FT}
     u.=v
-    triangularsolve!(lu,u) || ErrorException("Triangular Solve.")
-    lu._trisolvedone = false
-    u
+    return ldiv!(lu, u)
 end
 
 """
-    ldiv(lu::SparseSolver,v)
+    ldiv!(lu::SparseSolver{IT,FT}, v) where {IT,FT}
 
 Overwriting left division for SparseSolver.
+
+The solution is returned in `v`, which is also the right hand side vector.
 """
 function LinearAlgebra.ldiv!(lu::SparseSolver{IT,FT}, v) where {IT,FT}
-    triangularsolve!(lu,v) || ErrorException("Triangular Solve.")
+    solve!(lu, v) || ErrorException("Triangular Solve.")
     lu._trisolvedone = false
     v
 end

--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -195,9 +195,8 @@ function solve!(s::SparseSolver{IT,FT}, rhs) where {IT,FT}
     symbolicfactor!(s) || ErrorException("Symbolic Factorization.")
     inmatrix!(s) || ErrorException("Matrix input.")
     factor!(s) || ErrorException("Numerical Factorization.")
-    temp=copy(rhs)
-    triangularsolve!(s,temp) || ErrorException("Triangular Solve.")
-    return temp
+    triangularsolve!(s,rhs) || ErrorException("Triangular Solve.")
+    return true
 end
 
 #########################################################################

--- a/test/test_problem.jl
+++ b/test/test_problem.jl
@@ -51,3 +51,44 @@ end
 
 _test()
 end # module
+
+module mprob003
+using Test
+using LinearAlgebra
+using SparseArrays
+using Sparspak.SpkProblem
+
+function _test()
+    M, N = 15, 15
+    p = SpkProblem.Problem(M, N, 0.0)
+    spm = sprand(M, N, 0.2)
+    spm = spm + spm'
+    SpkProblem.insparse!(p, spm)
+    A = SpkProblem.outsparse(p)
+    @test spm - A == sparse(Int64[], Int64[], Float64[], M, N)
+    return true
+end
+
+_test()
+end # module
+
+module mprob004
+using Test
+using LinearAlgebra
+using SparseArrays
+using Sparspak.SpkProblem
+
+function _test()
+    M, N = 15, 15
+    p = SpkProblem.Problem(0, 0, 0.0)
+    p = SpkProblem.Problem(M, N, 0.0)
+    spm = sprand(M, N, 0.2)
+    spm = spm + spm'
+    SpkProblem.insparse!(p, spm)
+    A = SpkProblem.outsparse(p)
+    @test spm - A == sparse(Int64[], Int64[], Float64[], M, N)
+    return true
+end
+
+_test()
+end # module


### PR DESCRIPTION
@j-fu I would like to enable `\` on the solver without a prior factorization. For this purpose I have replaced the logic in `ldiv!` with `solve!`. All tests pass. Please tell me what you think.