### PR TITLE
SparseCSCInterface sparspaklu! check sparsity pattern

### DIFF
--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -255,7 +255,8 @@ and symbolic factorization are updated.
 If `allow_pattern_change = false` an error is thrown if the nonzero pattern of `m` is different to that 
 of the matrix used to create the LU factorization `lu`.
 
-If `lu` was created with option `factorize = false` then `lu` is always updated from `m` and `allow_pattern_change` is ignored.
+If `lu` has not been factorized (ie it has just been created with option `factorize = false`) then 
+`lu` is always updated from `m` and `allow_pattern_change` is ignored.
 
 """
 function sparspaklu!(lu::SparseSolver{IT,FT}, m::SparseMatrixCSC{FT,IT}; allow_pattern_change=true) where {FT,IT}

--- a/src/SparseMethod/SpkSparseSolver.jl
+++ b/src/SparseMethod/SpkSparseSolver.jl
@@ -31,6 +31,13 @@ mutable struct SparseSolver{IT, FT}
     _condestdone::Bool
 end
 
+function Base.copy!(dst::SparseSolver, src::SparseSolver)
+    for f in fieldnames(SparseSolver)
+        setfield!(dst, f,  getfield(src, f))
+    end
+    return dst
+end
+
 """
     SparseSolver(p::Problem)
 

--- a/src/SparseMethod/SpkSparseSolver.jl
+++ b/src/SparseMethod/SpkSparseSolver.jl
@@ -78,11 +78,11 @@ Given a symmetric matrix `A`, the steps are:
 The solution can be retrieved as `p.x`.
 """
 function solve!(s::SparseSolver{IT}) where {IT}
-    findorder!(s) || ErrorException("Finding Order.")
-    symbolicfactor!(s) || ErrorException("Symbolic Factorization.")
-    inmatrix!(s) || ErrorException("Matrix input.")
-    factor!(s) || ErrorException("Numerical Factorization.")
-    triangularsolve!(s) || ErrorException("Triangular Solve.")
+    findorder!(s) || error("Finding Order.")
+    symbolicfactor!(s) || error("Symbolic Factorization.")
+    inmatrix!(s) || error("Matrix input.")
+    factor!(s) || error("Numerical Factorization.")
+    triangularsolve!(s) || error("Triangular Solve.")
     return true
 end
 

--- a/src/SparseSpdMethod/SpkSparseSpdSolver.jl
+++ b/src/SparseSpdMethod/SpkSparseSpdSolver.jl
@@ -205,11 +205,11 @@ Given a symmetric matrix `A`, the steps are:
 The solution can be retrieved as `p.x`.
 """
 function solve!(s::SparseSpdSolver{IT}) where {IT}
-    findorder!(s) || ErrorException("Finding Order.")
-    symbolicfactor!(s) || ErrorException("Symbolic Factorization.")
-    inmatrix!(s) || ErrorException("Matrix input.")
-    factor!(s) || ErrorException("Numerical Factorization.")
-    triangularsolve!(s) || ErrorException("Triangular Solve.")
+    findorder!(s) || error("Finding Order.")
+    symbolicfactor!(s) || error("Symbolic Factorization.")
+    inmatrix!(s) || error("Matrix input.")
+    factor!(s) || error("Numerical Factorization.")
+    triangularsolve!(s) || error("Triangular Solve.")
     return true
 end
 

--- a/test/test_cscinterface.jl
+++ b/test/test_cscinterface.jl
@@ -146,10 +146,10 @@ function _test(T=Float64, n=20)
     rhs = spm2*exsol
 
     # test fails attempting to reuse factorisation lu
-    @test_throws ErrorException sparspaklu!(lu,spm2)
+    @test_throws ErrorException sparspaklu!(lu,spm2; allow_pattern_change=false)
 
-    # test without reusing factorisation lu
-    sparspaklu!(lu,spm2; reuse_symbolic=false)
+    # test with default allow_pattern_change == true
+    sparspaklu!(lu,spm2)
     sol=lu\rhs
     @test sol≈exsol
     
@@ -183,13 +183,19 @@ function _test_asymmetric(T=Float64, n=20)
     rhs = spm2*exsol
 
     # test fails attempting to reuse factorisation lu
-    @test_throws ErrorException sparspaklu!(lu,spm2)
+    @test_throws ErrorException sparspaklu!(lu,spm2; allow_pattern_change=false)
 
-    # test without reusing factorisation lu
-    sparspaklu!(lu,spm2; reuse_symbolic=false)
+    # test with default allow_pattern_change=true (will redo symbolic factorization)
+    sparspaklu!(lu,spm2)
     sol=lu\rhs
     @test sol≈exsol
-    
+
+    # test with uninitialized lu 
+    lu_nofact = sparspaklu(spzeros(1, 1); factorize=false)
+    sparspaklu!(lu_nofact,spm2; allow_pattern_change=false) # always allow update of unfactorized lu
+    sol=lu_nofact\rhs
+    @test sol≈exsol
+
 end
 
 _test_asymmetric(Float64)

--- a/test/test_cscinterface.jl
+++ b/test/test_cscinterface.jl
@@ -137,7 +137,19 @@ function _test(T=Float64, n=20)
 
     spm.nzval.-=0.1
     rhs = spm*exsol
-    lu=sparspaklu!(lu,spm)
+    sparspaklu!(lu,spm)
+    sol=lu\rhs
+    @test sol≈exsol
+
+    # create a matrix with different sparsity pattern
+    spm2 = spm + sprand(T, n, n, 1/n)
+    rhs = spm2*exsol
+
+    # test fails attempting to reuse factorisation lu
+    @test_throws ErrorException sparspaklu!(lu,spm2)
+
+    # test without reusing factorisation lu
+    sparspaklu!(lu,spm2; reuse_symbolic=false)
     sol=lu\rhs
     @test sol≈exsol
     


### PR DESCRIPTION
Robustness fix to the existing implementation of `sparsepaklu!`, adding a check for a change in the sparsity pattern, and adding `allow_pattern_change` argument to optionally error if sparsity pattern has changed.

    sparspaklu!(lu::SparseSolver, m::SparseMatrixCSC; allow_pattern_change=true) -> lu::SparseSolver

Updated docstring now reads:

*Calculate LU factorization of a sparse matrix `m`, reusing ordering and symbolic factorization `lu`, if that was previously calculated.*

*If `allow_pattern_change = true` (the default) the sparse matrix `m` may have a nonzero pattern different to that of the matrix used to create the LU factorization `lu`, in which case the ordering and symbolic factorization are updated.*

*If `allow_pattern_change = false` an error is thrown if the nonzero pattern of `m` is different to that  of the matrix used to create the LU factorization `lu`.*

*If `lu` has not been factorized (ie it has just been created with option `factorize = false`) then  `lu` is always updated from `m` and `allow_pattern_change` is ignored.*

 NB: this check is efficient as possible I think, but does need to compare `colptr` and `rowval` arrays, however this should be inexpensive compared to the actual factorization.

Also some bug fixes:
- sparspaklu! always mutate and update 'lu'
- ErrorExceptions were created, but not actually thrown ! Fix by
 replacing ErrorException() with error()

NB: there is a wrong turn in the first commit (attempting to compare sparsity pattern against the stored graph, which doesn't work as the graph may be modified with an asymmetric matrix), so suggest squash when merging...