### PR TITLE
Critical fix for error introduced by CSC changes in PR 28

### DIFF
--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -276,7 +276,7 @@ The solution is returned in `u`. The right hand side vector is `v`.
 """
 function LinearAlgebra.ldiv!(u, lu::SparseSolver{IT,FT}, v) where {IT,FT}
     u.=v
-    return ldiv!(lu, u)
+    return LinearAlgebra.ldiv!(lu, u)
 end
 
 """


### PR DESCRIPTION
Fix error introduced by https://github.com/PetrKryslUCSD/Sparspak.jl/pull/28

Caught by downstream tests for LinearSolve.jl, problem was a missing LinearAlgebra.ldiv!