### PR TITLE
Replace fill(zero(T), n) by zeros(T,n)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: julia-actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sparspak"
 uuid = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
 authors = ["Petr Krysl <pkrysl@ucsd.edu>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/ETree/SpkETree.jl
+++ b/src/ETree/SpkETree.jl
@@ -28,7 +28,7 @@ end
 Construct elimination tree.
 """
 function ETree(nv::IT) where {IT}
-    parent = fill(zero(IT), nv)
+    parent = zeros(IT, nv)
     return ETree(nv, parent)
 end
 
@@ -61,7 +61,7 @@ end
 #    ancestor - the ancestor vector.
 function _findetree!(n, xadj, adj, rperm, rinvp, parent)
 #
-    ancestor = fill(zero(eltype(xadj)), n)
+    ancestor = zeros(eltype(xadj), n)
     for i in 1:n
         parent[i] = 0; ancestor[i] = 0; vertex = rperm[i]
         for j = xadj[vertex]:(xadj[vertex + 1] - 1)
@@ -104,10 +104,10 @@ Updated Parameters:
 - `order` - the required ordering
 """
 function _getpostorder!(t::ETree{IT}, order::Ordering, weight) where {IT}
-    firstson = fill(zero(IT), t.nv)
-    brother = fill(zero(IT), t.nv)
-    stack = fill(zero(IT), t.nv)
-    invpos = fill(zero(IT), t.nv)
+    firstson = zeros(IT, t.nv)
+    brother = zeros(IT, t.nv)
+    stack = zeros(IT, t.nv)
+    invpos = zeros(IT, t.nv)
 
     _weightedbinarytree!(t.nv, t.parent, weight, firstson, brother)
 
@@ -123,10 +123,10 @@ function _getpostorder!(t::ETree{IT}, order::Ordering, weight) where {IT}
 end
 
 function _getpostorder!(t::ETree{IT}, order::Ordering) where {IT}
-    firstson = fill(zero(IT), t.nv)
-    brother = fill(zero(IT), t.nv)
-    stack = fill(zero(IT), t.nv)
-    invpos = fill(zero(IT), t.nv)
+    firstson = zeros(IT, t.nv)
+    brother = zeros(IT, t.nv)
+    stack = zeros(IT, t.nv)
+    invpos = zeros(IT, t.nv)
 
     _binarytree!(t.nv, t.parent, firstson, brother)
 
@@ -238,7 +238,7 @@ end
 #    lson - last son vector.
 function _weightedbinarytree!(n, parent, weight, fson, brother)
 #
-    lson = fill(zero(eltype(fson)), n)
+    lson = zeros(eltype(fson), n)
     fson .= zero(eltype(fson)); brother .= zero(eltype(fson)); 
     lson .= zero(eltype(fson)); lroot = n
 # --

--- a/src/Graph/SpkGraph.jl
+++ b/src/Graph/SpkGraph.jl
@@ -64,8 +64,8 @@ function Graph(p::Problem{IT}, diagonal=false) where {IT}
     else
         nedges = p.nedges - p.dedges
     end
-    xadj = fill(zero(IT), nv + 1)
-    adj = fill(zero(IT), nedges)
+    xadj = zeros(IT, nv + 1)
+    adj = zeros(IT, nedges)
     
     k = 1
     for i in 1:p.ncols
@@ -111,8 +111,8 @@ function makestructuresymmetric(g::Graph{IT}) where {IT}
     #       looking at each element only once. The complexity of this
     #       code is O(nEdges).
     # 
-    c = fill(zero(IT), g.nv)
-    first = fill(zero(IT), g.nv)
+    c = zeros(IT, g.nv)
+    first = zeros(IT, g.nv)
     c .= 0
     first .= g.xadj[1:g.nv]
 
@@ -277,7 +277,7 @@ This works only for graphs that are symmetric.
 """
 function sortgraph!(g::Graph{IT}) where {IT}
     xadj = deepcopy(g.xadj)
-    adj = fill(zero(IT), g.nedges)   
+    adj = zeros(IT, g.nedges)   
     for i in 1: g.nv
         for j in g.xadj[i]:(g.xadj[i + 1] - 1)
             k = g.adj[j];   adj[xadj[k]] = i

--- a/src/Grid/SpkGrid.jl
+++ b/src/Grid/SpkGrid.jl
@@ -18,7 +18,7 @@ Construct a grid with a given number of spacings.
 """
 function Grid(h::IT, k::IT) where {IT}
     n = h * k; 
-    v = fill(zero(IT), h, k)
+    v = zeros(IT, h, k)
     for i in 1:h
         for j in 1:k
             v[i, j] = k * (i - 1) + j

--- a/src/Ordering/SpkOrdering.jl
+++ b/src/Ordering/SpkOrdering.jl
@@ -109,10 +109,10 @@ function Ordering(nrows::IT, ncols::IT) where {IT}
     nrowblks = 0
     ncolblks = 0
 
-    rperm = fill(zero(IT), nrows)
-    rinvp = fill(zero(IT), nrows)
-    cperm = fill(zero(IT), ncols)
-    cinvp = fill(zero(IT), ncols)
+    rperm = zeros(IT, nrows)
+    rinvp = zeros(IT, nrows)
+    cperm = zeros(IT, ncols)
+    cinvp = zeros(IT, ncols)
 
     rperm .= 1:nrows
     rinvp .= rperm

--- a/src/Problem/SpkProblem.jl
+++ b/src/Problem/SpkProblem.jl
@@ -153,12 +153,12 @@ function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where
     dnz = zero(IT)
     dedges = zero(IT)
     
-    head = fill(zero(IT), lenhead)
-    rhs = fill(zero(FT), lenrhs)
-    x = fill(zero(FT), lenhead)
-    link = fill(zero(IT), lenlink)
-    rowsubs = fill(zero(IT), lenlink)
-    values = fill(_BIGGY(), lenlink)
+    head = zeros(IT, lenhead)
+    rhs = zeros(FT, lenrhs)
+    x = zeros(FT, lenhead)
+    link = zeros(IT, lenlink)
+    rowsubs = zeros(IT, lenlink)
+    values = fill!(Vector{FT}(undef, lenlink), _BIGGY())
     rscales = FT[]
     cscales = FT[]
     

--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -35,8 +35,8 @@ function Graph(m::SparseArrays.SparseMatrixCSC{FT,IT}, diagonal=false) where {FT
     #jf if diagonal == true, we possibly can just use colptr & rowval
     #jf and skip the loop
    
-    xadj = fill(zero(IT), nv + 1)
-    adj = fill(zero(IT), nedges)
+    xadj = zeros(IT, nv + 1)
+    adj = zeros(IT, nedges)
 
     k = 1
     for i in 1:ncols

--- a/src/SparseMethod/SpkLUFactor.jl
+++ b/src/SparseMethod/SpkLUFactor.jl
@@ -67,8 +67,8 @@ function _lufactor!(n::IT, nsuper::IT, xsuper::Vector{IT}, snode::Vector{IT}, xl
 
     ONE = one(FT)
     
-    link = fill(zero(IT), nsuper)
-    lngth = fill(zero(IT), nsuper)
+    link = zeros(IT, nsuper)
+    lngth = zeros(IT, nsuper)
 #
     iflag = zero(IT);   tmpsiz = zero(IT)
 #   Initialization
@@ -80,9 +80,9 @@ function _lufactor!(n::IT, nsuper::IT, xsuper::Vector{IT}, snode::Vector{IT}, xl
         if (need > tmpsiz) tmpsiz = need; end
     end
 
-    map = fill(zero(IT), n)
-    relind = fill(zero(IT), n)
-    temp = fill(zero(FT), tmpsiz)
+    map = zeros(IT, n)
+    relind = zeros(IT, n)
+    temp = zeros(FT, tmpsiz)
     vtemp = view(temp, 1:length(temp))
 
 #   For each supernode jsup ...
@@ -289,7 +289,7 @@ function _lulsolve!(nsuper::IT, xsuper::Vector{IT}, xlindx::Vector{IT}, lindx::V
         maxlngth = max(lngth, maxlngth)
     end
 
-    temp = fill(zero(FT), maxlngth)
+    temp = zeros(FT,maxlngth)
 
 # -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 #    forward substitution ...
@@ -342,7 +342,7 @@ function _luusolve!(n::IT, nsuper::IT, xsuper::Vector{IT}, xlindx::Vector{IT}, l
         maxlngth = max(lngth, maxlngth)
     end
 
-    temp = fill(zero(FT), maxlngth)
+    temp = zeros(FT, maxlngth)
 
 # -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 #    backward substitution ...

--- a/src/SparseMethod/SpkSparseBase.jl
+++ b/src/SparseMethod/SpkSparseBase.jl
@@ -197,9 +197,9 @@ function _symbolicfactor!(s::_SparseBase{IT, FT}) where {IT, FT}
         return false
     end
 
-    s.colcnt = fill(zero(IT), s.n)
-    s.snode = fill(zero(IT), s.n)
-    s.xsuper = fill(zero(IT), s.n + 1)
+    s.colcnt = zeros(IT, s.n)
+    s.snode = zeros(IT, s.n)
+    s.xsuper = zeros(IT, s.n + 1)
 
 # -  -  -  -  -  -  -  -  -
 #       Compute elimination tree
@@ -219,15 +219,15 @@ function _symbolicfactor!(s::_SparseBase{IT, FT}) where {IT, FT}
     s.nsub, s.nsuper = _findsupernodes!(s.g.nv, s.t.parent, s.colcnt, s.nsub, s.nsuper, s.xsuper, s.snode, s.maxblocksize)
     s.xsuper = __extend(s.xsuper, s.nsuper + 1)
 
-    s.lindx = fill(zero(IT), s.nsub)
-    s.xlindx = fill(zero(IT), s.nsuper + 1)
+    s.lindx = zeros(IT, s.nsub)
+    s.xlindx = zeros(IT, s.nsuper + 1)
 
 # -
 #       setup for symbolic factorization.
 # -
-    s.xlnz = fill(zero(IT), s.n + 1)
-    s.xunz = fill(zero(IT), s.n + 1)
-    s.ipiv = fill(zero(IT), s.n)
+    s.xlnz = zeros(IT, s.n + 1)
+    s.xunz = zeros(IT, s.n + 1)
+    s.ipiv = zeros(IT, s.n)
 
 # -
 #       Set up the data structure for the Cholesky factor.
@@ -239,8 +239,8 @@ function _symbolicfactor!(s::_SparseBase{IT, FT}) where {IT, FT}
 # -
 #       We now know how many elements we need, so allocate for it.
 # -
-    s.lnz = fill(zero(FT), s.xlnz[s.n + 1] - 1)
-    s.unz = fill(zero(FT), s.xunz[s.n + 1] - 1)
+    s.lnz = zeros(FT, s.xlnz[s.n + 1] - 1)
+    s.unz = zeros(FT, s.xunz[s.n + 1] - 1)
 
 
     s.lnz[1:s.xlnz[s.n + 1] - 1] .= zero(FT)
@@ -403,7 +403,7 @@ function _triangularsolve!(s::_SparseBase{IT, FT}, solution::AbstractVector{FT})
         return false
     end
 
-    rhs = fill(zero(FT), s.n)
+    rhs = zeros(FT, s.n)
     rhs .= solution[s.order.rperm]
 
     _lulsolve!(s.nsuper, s.xsuper, s.xlindx, s.lindx, s.xlnz, s.lnz, s.ipiv, rhs)

--- a/src/SparseSpdMethod/SpkLDLtFactor.jl
+++ b/src/SparseSpdMethod/SpkLDLtFactor.jl
@@ -71,11 +71,11 @@ function ldltfactor!(n, nsuper, xsuper, snode , xlindx , lindx, xlnz, lnz)
         maxwidth = max(maxwidth, width)
     end
 
-    map = fill(zero(IT), n)
-    relind = fill(zero(IT), n)
-    diag = fill(zero(IT), nmaxwidth)
-    temp = fill(zero(FT), tmpsiz)
-    temp2 = fill(zero(FT), maxwidth * maxwidth)
+    map = zeros(IT, n)
+    relind = zeros(IT, n)
+    diag = zeros(IT, nmaxwidth)
+    temp = zeros(FT, tmpsiz)
+    temp2 = zeros(FT, maxwidth * maxwidth)
 
 #      for each supernode jsup ...
        for jj  in  1: nsuper

--- a/src/SparseSpdMethod/SpkMMD.jl
+++ b/src/SparseSpdMethod/SpkMMD.jl
@@ -83,16 +83,16 @@ function _generalmmd(n::IT, xadj::Vector{IT}, adj::Vector{IT}, perm::Vector{IT},
     #
     adjncy = deepcopy(adj[1:(xadj[n+1]-1)])
 
-    deghead1 = fill(zero(IT), n)
+    deghead1 = zeros(IT, n)
     deghead = OffsetArray(deghead1, 0:(n-1))
 
-    marker = fill(zero(IT), n)
-    mergeparent = fill(zero(IT), n)
-    needsupdate = fill(zero(IT), n)
-    degnext = fill(zero(IT), n)
-    degprev = fill(zero(IT), n)
-    supersize = fill(zero(IT), n)
-    elimnext = fill(zero(IT), n)
+    marker = zeros(IT, n)
+    mergeparent = zeros(IT, n)
+    needsupdate = zeros(IT, n)
+    degnext = zeros(IT, n)
+    degprev = zeros(IT, n)
+    supersize = zeros(IT, n)
+    elimnext = zeros(IT, n)
     #
     #       Initialization for the minimum degree algorithm.
     #
@@ -591,7 +591,7 @@ function _mmdnumber(neqns, perm, invp, mergeparent)
 #           Initially, no nodes except roots in the
 #           merged forest have been numbered.
 # ----------------------------------------
-    mergelastnum = fill(zero(eltype(perm)), neqns)
+    mergelastnum = zeros(eltype(perm), neqns)
     ix = findall(mergeparent .== 0)
     mergelastnum[ix] = invp[ix]
 # -------------------------------------------------------

--- a/src/SparseSpdMethod/SpkSparseSpdBase.jl
+++ b/src/SparseSpdMethod/SpkSparseSpdBase.jl
@@ -181,9 +181,9 @@ function _symbolicfactor!(s::_SparseSpdBase{IT, FT}) where {IT, FT}
         return false
     end
 
-    s.colcnt = fill(zero(IT), s.n)
-    s.snode = fill(zero(IT), s.n)
-    s.xsuper = fill(zero(IT), s.n + 1)
+    s.colcnt = zeros(IT, s.n)
+    s.snode = zeros(IT, s.n)
+    s.xsuper = zeros(IT, s.n + 1)
 
 # -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 #       Compute elimination tree
@@ -203,14 +203,14 @@ function _symbolicfactor!(s::_SparseSpdBase{IT, FT}) where {IT, FT}
     s.nsub, s.nsuper = _findsupernodes!(s.g.nv, s.t.parent, s.colcnt, s.nsub, s.nsuper, s.xsuper, s.snode, s.maxblocksize)
     s.xsuper = __extend(s.xsuper, s.nsuper + 1)
 
-    s.lindx = fill(zero(IT), s.nsub)
-    s.xlindx = fill(zero(IT), s.nsuper + 1)
+    s.lindx = zeros(IT, s.nsub)
+    s.xlindx = zeros(IT, s.nsuper + 1)
 
 #-
 #       NEXT LINE CHANGED SINCE LNZ NOW CONTAINS RECTANGULAR SUPERNODES,
 #       NOT TRAPEZOIDAL, ie. some 0 elements are going to be stored
 #-
-    s.xlnz = fill(zero(IT), s.n + 1)
+    s.xlnz = zeros(IT, s.n + 1)
 
 # -  -  -  -  -  -  -
 #       Set up the data structure for the Cholesky factor.
@@ -222,7 +222,7 @@ function _symbolicfactor!(s::_SparseSpdBase{IT, FT}) where {IT, FT}
 # -  -  -  -  -  - -
 #       We now know how many elements we need, so allocate for it.
 #-
-    s.lnz = fill(zero(FT), s.xlnz[s.n + 1])
+    s.lnz = zeros(FT, s.xlnz[s.n + 1])
 
 
     s.lnz[1:s.xlnz[s.n + 1]] .= zero(FT)

--- a/src/SparseSpdMethod/SpkSymFct.jl
+++ b/src/SparseSpdMethod/SpkSymFct.jl
@@ -36,7 +36,7 @@ using OffsetArrays
 #                          vertices visited in each row subtree.
 function _findcolumncounts!(n, xadj, adj, perm, invp, parent, colcnt, nlnz)
 #
-    marker = fill(zero(eltype(xadj)), n)
+    marker = zeros(eltype(xadj), n)
     nlnz = n
 #-  -  -
 #       for each row subtree ...
@@ -116,9 +116,9 @@ function _symbolicfact!(n, xadj, adj, perm, invp, colcnt, nsuper, xsuper, snode,
 #       tail   : end of list indicator (in rchlnk(*), not mrglnk(*)).
 #       mrglnk : create empty lists.
 #       marker : "unmark" the indices.
-    marker = fill(zero(eltype(xadj)), n)
-    mrglnk = fill(zero(eltype(xadj)), nsuper)
-    rchlnk1 = fill(zero(eltype(xadj)), n+1)
+    marker = zeros(eltype(xadj), n)
+    mrglnk = zeros(eltype(xadj), nsuper)
+    rchlnk1 = zeros(eltype(xadj), n+1)
     rchlnk = OffsetArray(rchlnk1, 0:n)
 # 
     nzend = 0;   head = 0;   tail = n + 1;   point = 1;
@@ -316,8 +316,8 @@ end
         # integer k, par, current, col
 
 function _findschedule!(nsuper, xsuper, snode, xlindx, lindx, schedule)
-    count = fill(zero(IT), nsuper)
-    parent = fill(zero(IT), nsuper)
+    count = zeros(IT, nsuper)
+    parent = zeros(IT, nsuper)
 
     _findsupernodetree!(nsuper, xsuper, snode, xlindx, lindx, parent)
 
@@ -417,7 +417,7 @@ function _findsupernodes!(n, parent, colcnt, nofsub, nsuper, xsuper, snode, maxs
         # integer :: parent(*), colcnt(*), xsuper(*), snode(*)
         # integer :: limit, index
         # real    :: delta, supsize
-    marker = fill(zero(eltype(parent)), n)
+    marker = zeros(eltype(parent), n)
 #
 #       compute the fundamental supernode partition.
 #-  -  -  -  -  -  -  -  -  -  -

--- a/src/Utilities/SpkUtilities.jl
+++ b/src/Utilities/SpkUtilities.jl
@@ -28,7 +28,7 @@ end
 #     __extend(v::Matrix, newrow::Integer, newcol::Integer, flagval=zero(eltype(v)))
 # Change the size of a matrix (smaller or larger).
 function __extend(v::Matrix, newrow::Integer, newcol::Integer, flagval=zero(eltype(v)))
-    tempv = fill(zero(eltype(v)), newrow, newcol)
+    tempv = zeros(eltype(v), newrow, newcol)
     lencol = size(v, 2)
     lenrow = size(v, 1); 
 


### PR DESCRIPTION
The reason is that in particular, FT may be a union type. Experimenting, I was able
to solve linear systems using Sparspak with units (using DynamicQuantities.jl) by introducing
an extra type Zero for additive zero and use 1.0 as multiplicative unit.
So FT = Union{Float64, Zero, Quantity{...}}

In this case, fill(zero(FT),n) would result in a Vector{Zero}, whereas
zeros(FT, n) would result in a Vector{FT}, as needed.