### PR TITLE
Fix precompilation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,21 @@ jobs:
           - 'nightly' # the last nightly buildx
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
+          - macOS-13 # intel
+          - macOS-14 # arm
         arch:
           - x64
+          - aarch64
+        exclude:
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
+          - os: macOS-13
+            arch: aarch64
+          - os: macOS-14
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # the lowest supported version
+          - '1.9' # the lowest supported version
           - '1' # the current stable version
           - 'nightly' # the last nightly buildx
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sparspak"
 uuid = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
 authors = ["Petr Krysl <pkrysl@ucsd.edu>"]
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -1,11 +1,11 @@
 module SparseCSCInterface
 import SparseArrays, LinearAlgebra
-using ..SpkGraph: Graph
+import ..SpkGraph: Graph
 using ..SpkOrdering: Ordering
 using ..SpkETree: ETree
-using ..SpkSparseBase: _SparseBase
-using ..SpkSparseSolver: SparseSolver, findorder!,symbolicfactor!,inmatrix!,factor!,triangularsolve!
-import ..SpkSparseSolver: solve!
+import ..SpkSparseBase: _SparseBase
+using ..SpkSparseSolver: findorder!,symbolicfactor!,inmatrix!,factor!,triangularsolve!
+import ..SpkSparseSolver: SparseSolver, solve!
 import ..SpkSparseBase: _inmatrix!
 
 

--- a/src/SparseSpdMethod/SpkSparseSpdSolver.jl
+++ b/src/SparseSpdMethod/SpkSparseSpdSolver.jl
@@ -13,7 +13,8 @@ module SpkSparseSpdSolver
 
 using ..SpkProblem: Problem
 using ..SpkSparseSpdBase: _SparseSpdBase
-import ..SpkSparseSpdBase: _findorder!, _symbolicfactor!, _inmatrix!, _factor!, _triangularsolve!
+import ..SpkSparseBase: _triangularsolve!
+import ..SpkSparseSpdBase: _findorder!, _symbolicfactor!, _inmatrix!, _factor!
 using SparseArrays
 
 

--- a/src/Sparspak.jl
+++ b/src/Sparspak.jl
@@ -11,10 +11,10 @@ include("SparseSpdMethod/SpkMMD.jl")
 include("SparseSpdMethod/SpkSymFct.jl")
 include("SparseSpdMethod/SpkSpdMMOps.jl")
 include("SparseSpdMethod/SpkLDLtFactor.jl")
-include("SparseSpdMethod/SpkSparseSpdBase.jl")
-include("SparseSpdMethod/SpkSparseSpdSolver.jl")
 include("SparseMethod/SpkLUFactor.jl")
 include("SparseMethod/SpkSparseBase.jl")
+include("SparseSpdMethod/SpkSparseSpdBase.jl")
+include("SparseSpdMethod/SpkSparseSpdSolver.jl")
 include("SparseMethod/SpkSparseSolver.jl")
 
 using .SpkProblem


### PR DESCRIPTION
See e.g. https://discourse.julialang.org/t/warning-about-importing-spksparsespdbase-triangularsolve/128195

EDIT: Fixes the following warnings on Julia 1.12 beta: 
```
2 dependencies successfully precompiled in 3 seconds. 12 already precompiled.
1 dependency had output during precompilation:
┌ Sparspak
│  WARNING: Imported binding SpkSparseSpdBase._triangularsolve! was undeclared at import time during import to SpkSparseSpdSolver.
│  WARNING: Constructor for type "Graph" was extended in `SparseCSCInterface` without explicit qualification or import.
│    NOTE: Assumed "Graph" refers to `SpkGraph.Graph`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Graph end`.
│    Hint: To silence the warning, qualify `Graph` as `SpkGraph.Graph` in the method signature or explicitly `import SpkGraph: Graph`.
│  WARNING: Constructor for type "_SparseBase" was extended in `SparseCSCInterface` without explicit qualification or import.
│    NOTE: Assumed "_SparseBase" refers to `SpkSparseBase._SparseBase`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function _SparseBase end`.
│    Hint: To silence the warning, qualify `_SparseBase` as `SpkSparseBase._SparseBase` in the method signature or explicitly `import SpkSparseBase: _SparseBase`.
│  WARNING: Constructor for type "SparseSolver" was extended in `SparseCSCInterface` without explicit qualification or import.
│    NOTE: Assumed "SparseSolver" refers to `SpkSparseSolver.SparseSolver`. Thisbehavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function SparseSolver end`.
│    Hint: To silence the warning, qualify `SparseSolver` as `SpkSparseSolver.SparseSolver` in the method signature or explicitly `import SpkSparseSolver: SparseSolver`.
└
```
