### PR TITLE
Support Int32-indexed SparseMatrixCSC end-to-end

### DIFF
--- a/src/Ordering/SpkOrdering.jl
+++ b/src/Ordering/SpkOrdering.jl
@@ -106,8 +106,8 @@ Input Parameter:
 """
 function Ordering(nrows::IT, ncols::IT) where {IT}
     #       The default is to set nRowBlks and nColBlks to 0.
-    nrowblks = 0
-    ncolblks = 0
+    nrowblks = zero(IT)
+    ncolblks = zero(IT)
 
     rperm = zeros(IT, nrows)
     rinvp = zeros(IT, nrows)

--- a/src/Problem/SpkProblem.jl
+++ b/src/Problem/SpkProblem.jl
@@ -49,7 +49,6 @@
 module SpkProblem
 
 using SparseArrays
-using LinearAlgebra.BLAS: BlasInt
 using ..SpkUtilities: _BIGGY, __extend
 using ..SpkGrid: Grid
 
@@ -102,7 +101,7 @@ Similarly, the user can improve efficiency by providing estimates for the number
 of rows and columns in the matrix via the optional keyword parameters `nrows`
 and `ncols`.
 """
-mutable struct Problem{IT<:BlasInt, FT}
+mutable struct Problem{IT<:Integer, FT}
     info::String
     # `lenhead` is the current length of the arrays `head` and `x`.
     lenhead::IT
@@ -143,7 +142,7 @@ end
 
 Construct a problem.
 """
-function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where {IT<:BlasInt, FT}
+function Problem(nrows::IT, ncols::IT, nnz::IT=2500, z::FT=0.0, info = "") where {IT<:Integer, FT}
     lenlink = nnz
     lenhead = ncols
     lenrhs = nrows
@@ -174,7 +173,7 @@ Input a matrix coefficient.
 
 The value is *added* to the existing contents.
 """
-function inaij!(p::Problem{IT,FT}, rnum, cnum, aij=zero(FT)) where {IT<:BlasInt, FT}
+function inaij!(p::Problem{IT,FT}, rnum, cnum, aij=zero(FT)) where {IT<:Integer, FT}
     if (rnum < 1 || cnum < 1)
         @warn "$(@__FILE__): invalid matrix subscripts $(rnum), $(cnum): input ignored"
         return false
@@ -255,7 +254,7 @@ end
 
 Input an entry of the right-hand side vector.
 """
-function inbi!(p::Problem{IT, FT}, rnum::IT, bi::FT) where {IT<:BlasInt, FT}
+function inbi!(p::Problem{IT, FT}, rnum::IT, bi::FT) where {IT<:Integer, FT}
     if (rnum < 1)
         error("Invalid rhs subscript $(rnum).")
         return false
@@ -277,7 +276,7 @@ Input sparse matrix.
 
 Build a problem from a sparse matrix.
 """
-function insparse!(p::Problem{IT,FT}, spm) where {IT<:BlasInt, FT}
+function insparse!(p::Problem{IT,FT}, spm) where {IT<:Integer, FT}
     I, J, V = findnz(spm)
     return insparse!(p, I, J, V)
 end
@@ -288,7 +287,7 @@ end
 
 Build a problem from a sparse matrix in the COO format.
 """
-function insparse!(p::Problem{IT,FT}, I::Vector{IT}, J::Vector{IT}, V::Vector{FT}) where {IT<:BlasInt, FT}
+function insparse!(p::Problem{IT,FT}, I::Vector{IT}, J::Vector{IT}, V::Vector{FT}) where {IT<:Integer, FT}
     for i in eachindex(I)
         if ! inaij!(p, I[i], J[i], V[i])
             return false 
@@ -302,7 +301,7 @@ end
 
 Output the sparse matrix.
 """
-function outsparse(p::Problem{IT,FT})  where {IT<:BlasInt, FT}
+function outsparse(p::Problem{IT,FT})  where {IT<:Integer, FT}
     if (p.nrows == 0 && p.ncols == 0) 
         return spzeros(p.nrows, p.ncols)
     end
@@ -337,7 +336,7 @@ Input:
 Output:
 - `p` - the Problem object to be filled
 """
-function makegridproblem(g::Grid{IT}) where {IT<:BlasInt}
+function makegridproblem(g::Grid{IT}) where {IT<:Integer}
     M1 = -1.0; FOUR = 4.0
     n = g.h * g.k
     p = Problem(n, n)
@@ -373,7 +372,7 @@ Input:
 Output:
 - `p` - the Problem object to be filled
 """
-function makegridproblem(h::IT, k::IT) where {IT<:BlasInt}
+function makegridproblem(h::IT, k::IT) where {IT<:Integer}
     g = Grid(h, k)
     return makegridproblem(g)
 end
@@ -509,7 +508,7 @@ Input:
 Updated:
 - `p` - the problem in which rhs is to be inserted.
 """
-function infullrhs!(p::Problem{IT,FT}, rhs)  where {IT<:BlasInt, FT}
+function infullrhs!(p::Problem{IT,FT}, rhs)  where {IT<:Integer, FT}
     for i in p.nrows:-1:1
         inbi!(p, i, FT(rhs[i]))
     end
@@ -517,21 +516,21 @@ function infullrhs!(p::Problem{IT,FT}, rhs)  where {IT<:BlasInt, FT}
 end
 
 """
-    zerorhs!(p::Problem{IT,FT})  where {IT<:BlasInt, FT}
+    zerorhs!(p::Problem{IT,FT})  where {IT<:Integer, FT}
 
 Zero out the right hand side vector.
 """
-function zerorhs!(p::Problem{IT,FT})  where {IT<:BlasInt, FT}
+function zerorhs!(p::Problem{IT,FT})  where {IT<:Integer, FT}
     p.rhs[:] .= zero(FT)
     return p
 end
 
 """
-    isstructuresymmetric(p::Problem{IT,FT})  where {IT<:BlasInt, FT}
+    isstructuresymmetric(p::Problem{IT,FT})  where {IT<:Integer, FT}
 
 Is the problem structurally symmetric?
 """
-function isstructuresymmetric(p::Problem{IT,FT})  where {IT<:BlasInt, FT}
+function isstructuresymmetric(p::Problem{IT,FT})  where {IT<:Integer, FT}
     for cnum  in  1:p.ncols
         ptr = p.head[cnum]
         while ( ptr > 0 )
@@ -545,12 +544,12 @@ function isstructuresymmetric(p::Problem{IT,FT})  where {IT<:BlasInt, FT}
 end
 
 """
-    ijpresent(p::Problem{IT,FT} rnum, cnum) where {IT<:BlasInt, FT}
+    ijpresent(p::Problem{IT,FT} rnum, cnum) where {IT<:Integer, FT}
 
 Check to see if the entry (rnum, cnum) is present.
 If it is, the routine returns .true., otherwise .false. is returned.
 """
-function ijpresent(p::Problem{IT,FT}, rnum, cnum) where {IT<:BlasInt, FT}
+function ijpresent(p::Problem{IT,FT}, rnum, cnum) where {IT<:Integer, FT}
     ptr = p.head[cnum]
     while ( ptr > 0 )
         if ( p.rowSubs[ptr] > rnum ) 

--- a/src/SparseCSCInterface/SparseCSCInterface.jl
+++ b/src/SparseCSCInterface/SparseCSCInterface.jl
@@ -10,17 +10,17 @@ import ..SpkSparseBase: _inmatrix!
 
 
 function Graph(m::SparseArrays.SparseMatrixCSC{FT,IT}, diagonal=false) where {FT,IT}
-    nv = size(m,1)
-    nrows = size(m,2)
-    ncols = size(m,1)
+    nv = convert(IT, size(m, 1))
+    nrows = convert(IT, size(m, 2))
+    ncols = convert(IT, size(m, 1))
     colptr = SparseArrays.getcolptr(m)
     rowval = SparseArrays.getrowval(m)
 
 
     if (diagonal)
-        nedges = SparseArrays.nnz(m)
+        nedges = convert(IT, SparseArrays.nnz(m))
     else
-        dedges=0
+        dedges = zero(IT)
         for i in 1:ncols
             for iptr in colptr[i]:colptr[i+one(IT)]-one(IT)
                 if  rowval[iptr]==i
@@ -29,12 +29,12 @@ function Graph(m::SparseArrays.SparseMatrixCSC{FT,IT}, diagonal=false) where {FT
                 end
             end
         end
-        nedges = SparseArrays.nnz(m) - dedges
+        nedges = convert(IT, SparseArrays.nnz(m)) - dedges
     end
-    
+
     #jf if diagonal == true, we possibly can just use colptr & rowval
     #jf and skip the loop
-   
+
     xadj = zeros(IT, nv + one(IT))
     adj = zeros(IT, nedges)
 
@@ -49,32 +49,32 @@ function Graph(m::SparseArrays.SparseMatrixCSC{FT,IT}, diagonal=false) where {FT
             end
         end
     end
-    
-    xadj[ncols+1] = k
-    
+
+    xadj[ncols+one(IT)] = k
+
     return Graph(nv, nedges, nrows, ncols, xadj, adj)
 end
 
 
 function _SparseBase(m::SparseArrays.SparseMatrixCSC{FT,IT}) where {IT,FT}
-    maxblocksize = convert(IT,30)   # This can be set by the user
-    
+    maxblocksize = convert(IT, 30)   # This can be set by the user
+
     tempsizeneed = zero(IT)
-    n = size(m,2)
-    nnz = SparseArrays.nnz(m)
+    n = convert(IT, size(m, 2))
+    nnz = convert(IT, SparseArrays.nnz(m))
     nnzl = zero(IT)
     nsub = zero(IT)
 
     nsuper = zero(IT)
     if (n > zero(IT))
-        nsuper = 1
+        nsuper = one(IT)
     end
 
     factorops = zero(FT)
     solveops = zero(FT)
     realstore = zero(FT)
     integerstore = zero(FT)
-    errflag = 0
+    errflag = zero(IT)
 
     order = Ordering(n)   # ordering object for the solver
     g = Graph(m)
@@ -169,8 +169,8 @@ function _inmatrix!(s::_SparseBase{IT, FT}, m::SparseArrays.SparseMatrixCSC{FT,I
 end
 
 function SparseSolver(m::SparseArrays.SparseMatrixCSC{FT,IT}) where {FT,IT}
-    ma = size(m,2)
-    na = size(m,1)
+    ma = convert(IT, size(m, 2))
+    na = convert(IT, size(m, 1))
     mc = zero(IT)
     nc = zero(IT)
     n = ma

--- a/src/SparseMethod/SpkSparseBase.jl
+++ b/src/SparseMethod/SpkSparseBase.jl
@@ -130,7 +130,7 @@ end
 # an elimination tree and an ordering object; these are also
 #  initialized in this routine.
 function _SparseBase(p::Problem{IT,FT}) where {IT,FT}
-    maxblocksize = 30   # This can be set by the user
+    maxblocksize = convert(IT, 30)   # This can be set by the user
 
     tempsizeneed = zero(IT)
     n = p.nrows
@@ -140,14 +140,14 @@ function _SparseBase(p::Problem{IT,FT}) where {IT,FT}
 
     nsuper = zero(IT)
     if (n > zero(IT))
-        nsuper = 1
+        nsuper = one(IT)
     end
 
     factorops = zero(FT)
     solveops = zero(FT)
     realstore = zero(FT)
     integerstore = zero(FT)
-    errflag = 0
+    errflag = zero(IT)
 
     order = Ordering(n)   # ordering object for the solver
     g = Graph(p)

--- a/src/SparseMethod/SpkSparseSolver.jl
+++ b/src/SparseMethod/SpkSparseSolver.jl
@@ -45,11 +45,11 @@ Create a sparse solver from a problem.
 
 The solver pulls all it needs from the problem.
 """
-function SparseSolver(p::Problem)
+function SparseSolver(p::Problem{IT,FT}) where {IT,FT}
     ma = p.nrows
     na = p.ncols
-    mc = 0
-    nc = 0
+    mc = zero(IT)
+    nc = zero(IT)
     n = ma
     slvr = _SparseBase(p)
     _orderdone = false

--- a/src/SparseSpdMethod/SpkSpdMMOps.jl
+++ b/src/SparseSpdMethod/SpkSpdMMOps.jl
@@ -38,7 +38,7 @@ end
 
 # output parameters:
 # lnz - contains columns modified by the update matrix.
-function _assmb!(tlen::IT, nj::IT, temp::Vector{FT}, relcol::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}, relind::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}, xlnz::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}, lnz::Vector{FT}, jlen::IT) where {IT, FT}
+function _assmb!(tlen::Integer, nj::Integer, temp::AbstractVector{FT}, relcol::AbstractVector{<:Integer}, relind::AbstractVector{<:Integer}, xlnz::AbstractVector{<:Integer}, lnz::AbstractVector{FT}, jlen::Integer) where {FT}
     for j in 1:nj
         lbot = xlnz[jlen - relcol[j] + 1] - 1
         @inbounds for k in 1:tlen
@@ -67,7 +67,7 @@ end
 #                  relative to the last index in the list.  more
 #                  precisely, it gives the distance of each index
 #                  from the last index in the list.
-function _ldindx!(jlen::IT, lindx::LT, indmap::Vector{IT}) where {IT, LT}
+function _ldindx!(jlen::Integer, lindx, indmap::AbstractVector{<:Integer})
     # indmap[lindx[1:jlen]] .= (jlen - 1):-1:0
     @assert length(lindx) >= jlen
     kk = (jlen - 1)
@@ -91,7 +91,7 @@ end
 #        relind - list relative indices.
 #
 # *
-function _igathr!(klen::IT, lindx::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}, indmap::Vector{IT}, relind::Vector{IT}) where {IT}
+function _igathr!(klen::Integer, lindx::AbstractVector{<:Integer}, indmap::AbstractVector{<:Integer}, relind::AbstractVector{<:Integer})
     # relind[1:klen] = indmap[lindx[1:klen]]
 
     @assert length(relind) >= klen
@@ -122,14 +122,14 @@ end
 
 # updated parameters -
 #     z       -   on output, z = z + xy.
-function _mmpyi!(m::IT, q::IT,
-    zindxr::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}, 
-    zindxc::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}, 
-    x::SubArray{FT, 1, Vector{FT}, Tuple{UnitRange{IT}}, true}, 
-    y::SubArray{FT, 1, Vector{FT}, Tuple{UnitRange{IT}}, true}, 
-    iz::Vector{IT},
-    z::Vector{FT},
-    relind::Vector{IT}, diag = one(FT)) where {IT, FT}
+function _mmpyi!(m::Integer, q::Integer,
+    zindxr::AbstractVector{<:Integer},
+    zindxc::AbstractVector{<:Integer},
+    x::AbstractVector{FT},
+    y::AbstractVector{FT},
+    iz::AbstractVector{<:Integer},
+    z::AbstractVector{FT},
+    relind::AbstractVector{<:Integer}, diag = one(FT)) where {FT}
     @assert length(x) >= m
     @assert length(y) >= q
     for k in 1:q
@@ -165,7 +165,7 @@ end
 #    updated parameters -
 #        a - on output, a has its rows swapped according to
 #                    a[i, k] = a[ipvt[i], k] (i hope)
-function _luswap!(m::IT, n::IT, a::SubArray{FT, 1, Vector{FT}, Tuple{UnitRange{IT}}, true}, lda::IT, ipvt::SubArray{IT, 1, Vector{IT}, Tuple{UnitRange{IT}}, true}) where {IT, FT}
+function _luswap!(m::Integer, n::Integer, a::AbstractVector{FT}, lda::Integer, ipvt::AbstractVector{<:Integer}) where {FT}
     for k in 1:n
         i = ipvt[k]
         ks = (k - 1)*lda + 1
@@ -183,35 +183,40 @@ end
 # by generic ones. The methods  are wrappers around ggemm! etc functions
 # which call  corresponding implementations  from Julia  linear algebra.
 #
-function _gemm!(transA::AbstractChar, transB::AbstractChar, m::IT, n::IT, k::IT,
+# Scalar integer parameters are accepted as `Integer` (not `IT`) so the
+# pure-Julia path also works when arithmetic upstream has promoted some
+# of these scalars to a wider type than the index integer of the vectors.
+# This is important when `IT <: Integer` is narrower than `Int` (e.g.,
+# `Int32` index arrays + arithmetic with `Int` literals).
+function _gemm!(transA::AbstractChar, transB::AbstractChar, m::Integer, n::Integer, k::Integer,
                 alpha::FT,
-                A::AbstractVector{FT}, lda::IT,
-                B::AbstractVector{FT}, ldb::IT,
+                A::AbstractVector{FT}, lda::Integer,
+                B::AbstractVector{FT}, ldb::Integer,
                 beta::FT,
-                C::AbstractVector{FT}, ldc::IT) where {IT,FT}
+                C::AbstractVector{FT}, ldc::Integer) where {FT}
     ggemm!(transA,transB,m,n,k,alpha,A,lda,B,ldb,beta,C,ldc)
 end
 
-function _gemv!(transA::AbstractChar, m::IT, n::IT,
+function _gemv!(transA::AbstractChar, m::Integer, n::Integer,
                 alpha::FT,
-                A::AbstractVector{FT}, lda::IT,
+                A::AbstractVector{FT}, lda::Integer,
                 X::AbstractVector{FT},
                 beta::FT,
-                Y::AbstractVector{FT}) where {IT,FT}
+                Y::AbstractVector{FT}) where {FT}
     ggemv!(transA,m,n,alpha,A,lda,X,beta,Y)
 end
 
-function _getrf!(m::IT, n::IT, A::AbstractVector{FT}, lda::IT, ipiv::AbstractVector{IT}) where {IT,FT}
+function _getrf!(m::Integer, n::Integer, A::AbstractVector{FT}, lda::Integer, ipiv::AbstractVector{IT}) where {IT,FT}
     ggetrf!(m,n,A,lda,ipiv)
 end
 
-function _trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, m::IT, n::IT, alpha::FT,
-    A::AT, lda::IT,
-    B::BT, ldb::IT) where {IT,FT, AT, BT}
+function _trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, m::Integer, n::Integer, alpha::FT,
+    A::AT, lda::Integer,
+    B::BT, ldb::Integer) where {FT, AT, BT}
     gtrsm!(side,uplo,transa,diag, m,n,alpha,A, lda, B, ldb)
 end
 
-function _laswp!(a::AbstractVector{FT}, lda::IT, k1::IT, k2::IT, ipiv::AbstractVector{IT}) where {IT,FT}
+function _laswp!(a::AbstractVector{FT}, lda::Integer, k1::Integer, k2::Integer, ipiv::AbstractVector{IT}) where {IT,FT}
     glaswp!(a,lda,k1,k2,ipiv)
 end
 
@@ -219,18 +224,24 @@ end
 # BLAS+LAPACK for standard floating point types
 #
 
+# BLAS-specialized variants. These require `BlasInt` for every integer scalar
+# and (for variants with an `ipiv`) `Vector{BlasInt}` for the pivoting array,
+# matching the C BLAS/LAPACK ABI. When the caller's index integer type is
+# narrower than `BlasInt` (e.g. `Int32` on a 64-bit system), dispatch falls
+# through to the generic `_gemm!` / `_getrf!` / … wrappers above, which call
+# the pure-Julia `ggemm!` / `ggetrf!` / … implementations.
 for (gemm, FT) in
         ((:dgemm_, :Float64),
          (:sgemm_, :Float32),
          (:zgemm_, :ComplexF64),
          (:cgemm_, :ComplexF32))
 @eval begin
-function _gemm!(transA::AbstractChar, transB::AbstractChar, m::IT, n::IT, k::IT,
+function _gemm!(transA::AbstractChar, transB::AbstractChar, m::BlasInt, n::BlasInt, k::BlasInt,
     alpha::$FT,
-    A::AbstractVector{$FT}, lda::IT,
-    B::AbstractVector{$FT}, ldb::IT,
+    A::AbstractVector{$FT}, lda::BlasInt,
+    B::AbstractVector{$FT}, ldb::BlasInt,
     beta::$FT,
-    C::AbstractVector{$FT}, ldc::IT) where {IT}
+    C::AbstractVector{$FT}, ldc::BlasInt)
     ccall((@blasfunc($gemm), libblas), Cvoid,
         (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
             Ref{BlasInt}, Ref{$FT}, Ptr{$FT}, Ref{BlasInt},
@@ -256,7 +267,7 @@ for (getrf, FT) in
          (:zgetrf_, :ComplexF64),
          (:cgetrf_, :ComplexF32))
 @eval begin
-function _getrf!(m::IT, n::IT, A::AbstractVector{$FT}, lda::IT, ipiv::AbstractVector{IT}) where {IT}
+function _getrf!(m::BlasInt, n::BlasInt, A::AbstractVector{$FT}, lda::BlasInt, ipiv::AbstractVector{BlasInt})
     info = Ref{BlasInt}()
     ccall((@blasfunc($getrf), libblas), Cvoid,
         (Ref{BlasInt}, Ref{BlasInt}, Ptr{$FT},
@@ -282,9 +293,9 @@ for (trsm, FT) in
          (:ztrsm_, :ComplexF64),
          (:ctrsm_, :ComplexF32))
 @eval begin
-    function _trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, m::IT, n::IT, alpha::$FT,
-                    A::AbstractVector{$FT}, lda::IT,
-                    B::AbstractVector{$FT}, ldb::IT) where {IT}
+    function _trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, m::BlasInt, n::BlasInt, alpha::$FT,
+                    A::AbstractVector{$FT}, lda::BlasInt,
+                    B::AbstractVector{$FT}, ldb::BlasInt)
     ccall((@blasfunc($trsm), libblas), Cvoid,
         (Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ref{UInt8},
             Ref{BlasInt}, Ref{BlasInt}, Ref{$FT}, Ptr{$FT},
@@ -312,7 +323,7 @@ for (laswp, FT) in
          (:zlaswp_, :ComplexF64),
          (:claswp_, :ComplexF32))
 @eval begin
-function _laswp!(a::AbstractVector{$FT}, lda::IT, k1::IT, k2::IT, ipiv::AbstractVector{IT}) where {IT}
+function _laswp!(a::AbstractVector{$FT}, lda::BlasInt, k1::BlasInt, k2::BlasInt, ipiv::AbstractVector{BlasInt})
     # dlaswp(1, rhs(fj), nj, 1, nj, ipiv(fj), 1)
     ccall((@blasfunc($laswp), libblas), Cvoid,
         (Ref{BlasInt}, Ptr{$FT}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt}, Ptr{BlasInt}, Ref{BlasInt}),
@@ -335,15 +346,15 @@ for (gemv, FT) in
          (:zgemv_, :ComplexF64),
          (:cgemv_, :ComplexF32))
 @eval begin
-    function _gemv!(trans::AbstractChar, m::IT, n::IT, alpha::$FT,
-    A::AbstractVector{$FT}, lda::IT,
+    function _gemv!(trans::AbstractChar, m::BlasInt, n::BlasInt, alpha::$FT,
+    A::AbstractVector{$FT}, lda::BlasInt,
     X::AbstractVector{$FT},
-    beta::$FT, Y::AbstractVector{$FT}) where {IT}
+    beta::$FT, Y::AbstractVector{$FT})
     ccall((@blasfunc($gemv), libblas), Cvoid,
         (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$FT},
             Ptr{$FT}, Ref{BlasInt}, Ptr{$FT}, Ref{BlasInt},
             Ref{$FT}, Ptr{$FT}, Ref{BlasInt}, Clong),
-        trans, m, n, alpha, A, lda, X, 1, beta, Y, 1, 
+        trans, m, n, alpha, A, lda, X, 1, beta, Y, 1,
         1)
     Y
 end

--- a/src/Utilities/GenericBlasLapackFragments.jl
+++ b/src/Utilities/GenericBlasLapackFragments.jl
@@ -29,8 +29,15 @@ using LinearAlgebra
 # The @inbounds macros in the accessor methods are the only ones in this
 # package (besides of glawsp)
 
-struct StridedReshape{Tv,Ti}
-    v::Union{Vector{Tv},SubArray{Tv, 1, Vector{Tv}, Tuple{UnitRange{Ti}}, true}}
+# Previously `StridedReshape{Tv,Ti}` constrained the underlying buffer to be a
+# `Vector{Tv}` or a `SubArray` over a `UnitRange{Ti}`, which forced the index
+# integer type of the slice to match the `lda` integer type. That fails when
+# `lda` is `Int32` (derived from a `SparseMatrixCSC{Float64,Int32}`) but the
+# slice was materialized with `Int` ranges. The buffer and the `lda` integer
+# type are now independent type parameters so the wrapper accepts mixed-index
+# views without copying.
+struct StridedReshape{Tv,Ti<:Integer,V<:AbstractVector{Tv}}
+    v::V
     lda::Ti
 end
 

--- a/test/test_cscinterface.jl
+++ b/test/test_cscinterface.jl
@@ -201,3 +201,53 @@ end
 _test_asymmetric(Float64)
 
 end
+
+
+# Int32-indexed CSC matrices.  Sparspak historically required the index integer
+# type to equal `BlasInt` (Int64) so a `SparseMatrixCSC{Float64,Int32}` failed
+# in the constructors of `Graph` / `_SparseBase` / `Ordering` / `SparseSolver`
+# (mismatched scalar/array element types) and in the LU factorization path
+# (BLAS-typed scalars expected throughout). Exercise both index types here so
+# the matrix builds, factors, and solves without copying to Int64.
+module csc_int32_solver
+using Test
+using LinearAlgebra
+using SparseArrays
+using Sparspak
+using Random
+
+function _test(T, IT, n=8)
+    Random.seed!(42)
+    spm_default = sprand(T, n, n, 0.4)
+    spm_default = spm_default + n * LinearAlgebra.I
+    spm = SparseMatrixCSC{T, IT}(spm_default)
+    @test typeof(spm) === SparseMatrixCSC{T, IT}
+
+    # Solver constructed without factorization (the path LinearSolve.jl uses
+    # during init_cacheval — this must not throw even if a downstream BLAS
+    # call would not yet support `IT`).
+    lu_nofact = sparspaklu(spm; factorize=false)
+    @test lu_nofact isa Sparspak.SpkSparseSolver.SparseSolver{IT, T}
+
+    # Full factor-and-solve.
+    exsol = ones(T, n)
+    rhs = spm * exsol
+    lu = sparspaklu(spm)
+    sol = lu \ rhs
+    @test sol ≈ exsol
+
+    # Update values only (same pattern) and re-solve.
+    spm.nzval .-= T(0.1)
+    rhs = spm * exsol
+    sparspaklu!(lu, spm)
+    sol = lu \ rhs
+    @test sol ≈ exsol
+end
+
+for IT in (Int32, Int64)
+    for T in (Float64, Float32, ComplexF64, ComplexF32)
+        _test(T, IT)
+    end
+end
+
+end


### PR DESCRIPTION
> **Note:** Please ignore this PR until reviewed by @ChrisRackauckas. Opening it draft to keep CI honest; happy to revise / split if the scope is too broad in one shot.

## What

`sparspaklu(::SparseMatrixCSC{Float64, Int32})` (and the other BLAS float × Int32 combinations) used to fail. Two layers of breakage:

1. **Constructors of `Graph` / `_SparseBase` / `Ordering` / `SparseSolver`** mixed `Int64` scalars (from `size`, `nnz`, bare integer literals like `0`/`1`/`30`) with `Int32` vectors, so the inner `where {IT}` constructor never matched. The most-visible symptom was:
   ```
   MethodError: no method matching Sparspak.SpkGraph.Graph(::Int64, ::Int64, ::Int64, ::Int64, ::Vector{Int32}, ::Vector{Int32})
   ```
2. **`_lufactor!` → `_getrf!` / `_gemm!` / `_trsm!` / `_laswp!` / `_gemv!` / `_luswap!` / `_mmpyi!` / `_assmb!` / `_ldindx!` / `_igathr!`** required every scalar *and* the ipiv vector to share the same `IT`. Internal arithmetic widens `Int32` to `Int` (`fj + 1`, `lj - fj + 1`, …), so dispatch failed once you got past construction. And even when it didn't, the libblas-bound specializations reinterpreted a `Vector{Int32}` ipiv as `Ptr{BlasInt}` (Int64), so the fast path was unsafe for any `IT != BlasInt` anyway.

## Approach

I tried to keep the diff small by relaxing dispatch rather than rewriting arithmetic.

- **Constructors** in `Graph(::SparseMatrixCSC)`, `_SparseBase(::SparseMatrixCSC)`, `_SparseBase(::Problem)`, `Ordering`, and both `SparseSolver` methods convert every scalar to `IT` so the inner struct constructor type-checks. Bare literals (`0`/`1`/`30`) become `zero(IT)`/`one(IT)`/`convert(IT, 30)`.
- **`Problem{IT<:Integer, FT}`** instead of `Problem{IT<:BlasInt, FT}`. This is needed because `SparseSolver{IT, FT}` stores `p::Union{Problem{IT,FT}, SparseMatrixCSC{FT,IT}}`, and for `IT == Int32` the `Problem{Int32, FT}` arm was invalid (Int32 !<: BlasInt), which made the whole Union collapse to `Union{}`. I dropped the now-unused `using LinearAlgebra.BLAS: BlasInt` in `SpkProblem.jl`.
- **Generic wrappers** (`_gemm!`, `_gemv!`, `_getrf!`, `_trsm!`, `_laswp!`, `_luswap!`, `_mmpyi!`, `_assmb!`, `_ldindx!`, `_igathr!`) now take `Integer` for scalars and `AbstractVector{<:Integer}` for index vectors. Internal arithmetic in `_lufactor!` still promotes `Int32` to `Int` in some places; with the relaxed signatures that no longer breaks dispatch.
- **libblas-bound specializations** (`dgemm_` / `dgetrf_` / `dtrsm_` / `dlaswp_` / `dgemv_` and the float-32/complex variants) now require `BlasInt` for every integer scalar *and* `Vector{BlasInt}` for the pivoting vector. For any `IT != BlasInt`, dispatch falls through to the generic wrappers above, which call the pure-Julia `ggemm!` / `ggetrf!` / etc. So Int32 stays safe (no Int32 ipiv → BlasInt ptr reinterpretation) and Int64 still hits the fast BLAS path.
- **`StridedReshape{Tv, Ti, V<:AbstractVector{Tv}}`** no longer requires the underlying view's range integer type to match `lda`'s integer type. Previously `Union{Vector{Tv}, SubArray{Tv, 1, Vector{Tv}, Tuple{UnitRange{Ti}}, true}}` forced them to be the same; in practice `lda` is `Int32` (from a narrow index type) while the slice ranges are materialized with `Int`, so the constraint over-restricted with no benefit.

## Tests

Adds a `csc_int32_solver` module in `test/test_cscinterface.jl` that exercises `sparspaklu` and `sparspaklu!` across the cross product of `{Float32, Float64, ComplexF32, ComplexF64} × {Int32, Int64}`, including the `factorize = false` construction-only path that LinearSolve.jl uses during `init_cacheval`.

```
Test Summary: …
Problem | 5 5
Ordering | 2 2
Graph | 7 7
ETree | 1 1
Grid | 3 3
Generic LAPACK/BLAS | 41 41
Sparse method | 65 65
Generic floating type | 43 43
SparseMatrixCSC Interface | 57 57   ← was 51 before
Structurally unsymmetric | 5 5
Further tests of small unsymmetric matrices | 6 6
Testing Sparspak tests passed
```

Verified locally on Julia 1.11.9; full `Pkg.test()` clean.

## Why now / why this matters

This unblocks LinearSolve.jl's `DefaultLinearSolver` from crashing when the user hands it a `SparseMatrixCSC{Float64, Int32}` (see SciML/LinearSolve.jl#992 — the `_init_default_cacheval` there initializes every solver's cacheval, including Sparspak's, so a Sparspak constructor crash on Int32 took out the entire default solver init). With this PR, the LinearSolve workaround there can also be dropped on the next Sparspak release.